### PR TITLE
Fix an error on startup if Twilio credentials are not set.

### DIFF
--- a/scripts/pbx.coffee
+++ b/scripts/pbx.coffee
@@ -11,7 +11,11 @@ fromNumber = process.env.TWILIO_FROM_NUMBER
 phoneRoom = process.env.TWILIO_ROOM
 
 twilio = require('twilio');
-client = new twilio(accountSid, authToken);
+
+if accountSid? and authToken?
+	client = new twilio(accountSid, authToken);
+else
+	console.warn "WARNING: Twilio credentials are not set. Plugin 'pbx' will not work correctly."
 
 _ = require('lodash');
 


### PR DESCRIPTION
Sort of fixes  https://github.com/rogue-hack-lab/hackbot/issues/31

However, it's not an ideal solution since it just logs a warning - a better thing to do would probably be to add guards to the robot callbacks in the pbx script to handle Twilio client not being initialized.

But, this makes it so I can run the bot in dev.