### PR TITLE
Added new dice roller bot.

### DIFF
--- a/scripts/dice-roller.js
+++ b/scripts/dice-roller.js
@@ -1,0 +1,26 @@
+module.exports = function(robot) {
+    robot.hear(/roll ([0-9]+)d([0-9]+)/i, (response) => {
+        
+        let dice = {
+            count: response.match[1],
+            sides: response.match[2]
+        };
+
+        if (dice.count > 100) {
+            response.reply(`I don't like to roll more than 100 dice.`);
+            return;
+        }
+
+        let result = [];
+        for (let i =0; i <= dice.count-1; i++) {
+            result.push(generateRandom(dice.sides))
+        }
+
+        let total = result.reduce(aggregator);
+
+        response.reply(`You rolled ${result.join(', ')} for a total of: ${total}`);
+    });
+
+    let generateRandom = (max) => Math.floor(Math.random() * max) + 1;
+    let aggregator = (aggregate, value) => aggregate + value;
+};

--- a/test/dice-roller.spec.js
+++ b/test/dice-roller.spec.js
@@ -1,0 +1,27 @@
+const Helper = require('hubot-test-helper');
+const helper = new Helper('../scripts/dice-roller.js');
+
+const co = require('co');
+const { expect } = require('chai');
+
+describe('hackbot dice roller', () => {
+  beforeEach(function() {
+    this.room = helper.createRoom();
+  });
+
+  afterEach(function() {
+    this.room.destroy();
+  });
+
+  context('of a 1d20', function () {
+    beforeEach(function() {
+      return co(function*() {
+        yield this.room.user.say('josh', 'roll 2d20');
+      }.bind(this));
+    });
+
+    it('hackbot should roll dice', function() {
+      expect(this.room.messages[1][1]).to.match(/@josh You rolled [0-9]+, [0-9]+ for a total of: [0-9]+/i)
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a bot response to a dice roll request in the form of the command: `roll 1d20`. There are very few restrictions on the dice and types that you can roll, other than it will not roll more than 100 dice.