### PR TITLE
Fix double NPM install at runtime from Hubot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ upon have been set.
 
 You can start hackbot locally by running:
 
+    % npm install
     % bin/hubot
 
 You'll see some start up output and a prompt:

--- a/bin/hubot
+++ b/bin/hubot
@@ -2,7 +2,6 @@
 
 set -e
 
-npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
 exec node_modules/.bin/hubot --name "hackbot" "$@"


### PR DESCRIPTION
Npm install happens when the Docker image is built, but it happens again
before Hubot runs, thanks to `npm install` being in the `bin/hubot` script.

That's unnecessary and is causing build errors on npm install that
happens outside of the Docker build.